### PR TITLE
#41 Changed the handling of exceptions thrown on CollectionChanged ev…

### DIFF
--- a/ExamplesAndTests/Swordfish.NET.UnitTestV3/ConcurrentObservableCollection_INotifyCollectionChangedTests.cs
+++ b/ExamplesAndTests/Swordfish.NET.UnitTestV3/ConcurrentObservableCollection_INotifyCollectionChangedTests.cs
@@ -225,6 +225,44 @@ namespace Swordfish.NET.UnitTestV3
             Assert.IsTrue(CollectionsAreEqual(initial, returnedArgs.OldItems));
         }
 
+        [TestMethod]
+        public void Test_ConcurrentObservableCollection_ExceptionAbsorbedByDefault()
+        {
+            var collection = new ConcurrentObservableCollection<int>();
+            collection.CollectionChanged += (object sender, NotifyCollectionChangedEventArgs e) => throw new NotImplementedException();
+            collection.Add(1);
+            Assert.AreEqual(1, collection.Count);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(NotImplementedException))]
+        public void Test_ConcurrentObservableCollection_ExceptionNotAbsorbed()
+        {
+            var collection = new ConcurrentObservableCollection<int>();
+            collection.ExceptionEventHandler = null;
+            collection.CollectionChanged += (object sender, NotifyCollectionChangedEventArgs e) => throw new NotImplementedException();
+            collection.Add(1);
+            Assert.AreEqual(1, collection.Count);
+        }
+
+        [TestMethod]
+        public void Test_ConcurrentObservableCollection_ExceptionEventHandler()
+        {
+            var collection = new ConcurrentObservableCollection<int>();
+            var exception = new NotImplementedException();
+            collection.CollectionChanged += (object sender, NotifyCollectionChangedEventArgs e) => throw exception;
+            bool exceptionThrown = false;
+            collection.ExceptionEventHandler += (s, e) =>
+            {
+                exceptionThrown = true;
+                Assert.AreEqual(collection, s);
+                Assert.AreEqual(exception, e);
+            };
+            collection.Add(1);
+            Assert.AreEqual(1, collection.Count);
+            Assert.IsTrue(exceptionThrown);
+        }
+
         bool CollectionsAreEqual(IEnumerable<int> collectionA, IList collectionB) =>
             collectionA.Zip(collectionB.OfType<int>(), (a, b) => a == b).All(c => c);
     }

--- a/Swordfish.NET.CollectionsV3/ConcurrentObservableBase.cs
+++ b/Swordfish.NET.CollectionsV3/ConcurrentObservableBase.cs
@@ -177,6 +177,14 @@ namespace Swordfish.NET.Collections
         /// </summary>
         public bool AllowDirectBindingToView { get; set; } = false;
 
+        /// <summary>
+        /// This is used for handling exceptions in CollectionChanged event handlers.
+        /// By default, the exception event handler does nothing and quietly swallows the exception.
+        /// Setting this to null causes exceptions to be bubbled up to the caller that
+        /// modified the collection.
+        /// </summary>
+        public EventHandler<Exception> ExceptionEventHandler { get; set; } = (_1, _2) => { };
+
         // ************************************************************************
         // INotifyCollectionChanged Implementation
         // ************************************************************************
@@ -188,9 +196,13 @@ namespace Swordfish.NET.Collections
             {
                 _collectionChanged?.Invoke(this, changes);
             }
-            catch (Exception)
+            catch (Exception exception)
             {
-
+                // if there is no ExceptionEventHandler, rethrow the exception
+                if (ExceptionEventHandler is null)
+                    throw;
+                else
+                    ExceptionEventHandler?.Invoke(this, exception);
             }
         }
 

--- a/Swordfish.NET.CollectionsV3/VirtualizingCollectionAsync.cs
+++ b/Swordfish.NET.CollectionsV3/VirtualizingCollectionAsync.cs
@@ -53,9 +53,7 @@ namespace Swordfish.NET.Collections
         /// <param name="e">The <see cref="System.Collections.Specialized.NotifyCollectionChangedEventArgs"/> instance containing the event data.</param>
         protected virtual void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
         {
-            NotifyCollectionChangedEventHandler h = CollectionChanged;
-            if (h != null)
-                h(this, e);
+            CollectionChanged?.Invoke(this,e);
         }
 
         /// <summary>


### PR DESCRIPTION
…ent handlers. They can be silently absorbed (default), rethrown when the ExceptionEventHandler is set to null, or handled externally by setting the ExceptionEventHandler property to an external event handler.